### PR TITLE
fix: explicit tabIndex on all form fields in NewTransactionPage

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react'
+import React, { useId, useRef, useEffect, useState, useCallback } from 'react'
 import { cn } from '@/lib/utils'
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -103,23 +103,25 @@ interface SearchableSelectProps {
   className?: string
 }
 
-export const SearchableSelect = React.forwardRef<HTMLInputElement, SearchableSelectProps>(
-  ({ label, error, options, value, onChange, placeholder = 'Selecione...', disabled, className }, ref) => {
+export const SearchableSelect = React.forwardRef<HTMLButtonElement, SearchableSelectProps>(
+  ({ label, error, options, value, onChange, placeholder = 'Selecione...', disabled, className }, _ref) => {
     const generatedId = useId()
     const errorId = `${generatedId}-error`
-    const [isOpen, setIsOpen] = React.useState(false)
-    const [search, setSearch] = React.useState('')
-    const containerRef = React.useRef<HTMLDivElement>(null)
+    const [isOpen, setIsOpen] = useState(false)
+    const [search, setSearch] = useState('')
+    const containerRef = useRef<HTMLDivElement>(null)
+    const searchInputRef = useRef<HTMLInputElement>(null)
+    const triggerRef = useRef<HTMLButtonElement>(null)
 
     const selectedOption = options.find(opt => opt.value === value)
 
     const filteredOptions = React.useMemo(() => {
       if (!search) return options
-      const searchLower = search.toLowerCase()
-      return options.filter(opt => opt.label.toLowerCase().includes(searchLower))
+      return options.filter(opt => opt.label.toLowerCase().includes(search.toLowerCase()))
     }, [options, search])
 
-    React.useEffect(() => {
+    // Close on outside click
+    useEffect(() => {
       const handleClickOutside = (event: MouseEvent) => {
         if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
           setIsOpen(false)
@@ -130,25 +132,80 @@ export const SearchableSelect = React.forwardRef<HTMLInputElement, SearchableSel
       return () => document.removeEventListener('mousedown', handleClickOutside)
     }, [])
 
+    // Focus search input when dropdown opens
+    useEffect(() => {
+      if (isOpen && searchInputRef.current) {
+        searchInputRef.current.focus()
+      }
+    }, [isOpen])
+
     const handleSelect = (optionValue: string) => {
       onChange?.(optionValue)
       setIsOpen(false)
       setSearch('')
+      // Return focus to trigger after selection
+      triggerRef.current?.focus()
     }
+
+    const handleTriggerKeyDown = useCallback((e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        setIsOpen(prev => !prev)
+        if (!isOpen) {
+          setSearch('')
+        }
+      } else if (e.key === 'ArrowDown' && !isOpen) {
+        e.preventDefault()
+        setIsOpen(true)
+        setSearch('')
+      } else if (e.key === 'Escape' && isOpen) {
+        setIsOpen(false)
+        setSearch('')
+        triggerRef.current?.focus()
+      }
+    }, [isOpen])
+
+    const handleSearchKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        // Focus first option
+        const firstOption = containerRef.current?.querySelector('[role="option"]') as HTMLElement | null
+        firstOption?.focus()
+      } else if (e.key === 'Escape') {
+        setIsOpen(false)
+        setSearch('')
+        triggerRef.current?.focus()
+      }
+    }, [])
 
     return (
       <div className="space-y-2" ref={containerRef}>
         {label && (
-          <label className="text-sm font-medium text-gray-700">
+          <label id={`${generatedId}-label`} className="text-sm font-medium text-gray-700">
             {label}
           </label>
         )}
         <div className="relative">
-          <div
-            onClick={() => !disabled && setIsOpen(!isOpen)}
+          {/* The trigger — a real <button> so it gets focus and Tab works */}
+          <button
+            ref={triggerRef}
+            type="button"
+            role="combobox"
+            aria-expanded={isOpen}
+            aria-haspopup="listbox"
+            aria-labelledby={label ? `${generatedId}-label` : undefined}
+            aria-controls={`${generatedId}-listbox`}
+            disabled={disabled}
+            onClick={() => {
+              if (!disabled) {
+                setIsOpen(!isOpen)
+                if (!isOpen) setSearch('')
+              }
+            }}
+            onKeyDown={handleTriggerKeyDown}
             className={cn(
-              'flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm cursor-pointer',
-              'focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2',
+              'flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-left cursor-pointer',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
               error && 'border-red-500',
               disabled && 'cursor-not-allowed opacity-50',
               className
@@ -165,39 +222,80 @@ export const SearchableSelect = React.forwardRef<HTMLInputElement, SearchableSel
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
             </svg>
-          </div>
+          </button>
 
+          {/* Dropdown panel */}
           {isOpen && (
-            <div className="absolute z-50 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
-              <div className="p-2">
+            <div
+              className="absolute z-50 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg"
+              role="listbox"
+              id={`${generatedId}-listbox`}
+              aria-labelledby={label ? `${generatedId}-label` : undefined}
+            >
+              {/* Search input inside the listbox */}
+              <div className="border-b border-gray-100 p-2">
                 <input
-                  ref={ref}
+                  ref={searchInputRef}
                   type="text"
+                  role="searchbox"
+                  aria-label="Buscar"
+                  placeholder="Buscar..."
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Filtrar..."
-                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                  autoFocus
+                  onKeyDown={handleSearchKeyDown}
+                  className="w-full rounded border border-gray-200 px-2 py-1.5 text-sm outline-none focus:border-primary"
                 />
               </div>
-              <ul className="max-h-60 overflow-auto py-1">
+
+              <div className="max-h-60 overflow-y-auto p-1">
                 {filteredOptions.length === 0 ? (
-                  <li className="px-3 py-2 text-sm text-gray-500">Nenhum resultado</li>
+                  <p className="p-2 text-sm text-gray-500">Nenhuma opção encontrada</p>
                 ) : (
                   filteredOptions.map((option) => (
-                    <li
+                    <div
                       key={option.value}
+                      role="option"
+                      aria-selected={option.value === value}
+                      tabIndex={0}
                       onClick={() => handleSelect(option.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          handleSelect(option.value)
+                        } else if (e.key === 'ArrowDown') {
+                          e.preventDefault()
+                          const options = containerRef.current?.querySelectorAll('[role="option"]')
+                          const currentIndex = Array.from(options ?? []).indexOf(e.currentTarget as HTMLElement)
+                          const next = options?.[currentIndex + 1] as HTMLElement | undefined
+                          next?.focus()
+                        } else if (e.key === 'ArrowUp') {
+                          e.preventDefault()
+                          const options = containerRef.current?.querySelectorAll('[role="option"]')
+                          const currentIndex = Array.from(options ?? []).indexOf(e.currentTarget as HTMLElement)
+                          const prev = options?.[currentIndex - 1] as HTMLElement | undefined
+                          if (currentIndex === 0) {
+                            searchInputRef.current?.focus()
+                          } else {
+                            prev?.focus()
+                          }
+                        } else if (e.key === 'Escape') {
+                          setIsOpen(false)
+                          setSearch('')
+                          triggerRef.current?.focus()
+                        }
+                      }}
                       className={cn(
-                        'cursor-pointer px-3 py-2 text-sm hover:bg-gray-100',
-                        option.value === value && 'bg-primary/10 text-primary'
+                        'flex cursor-pointer items-center rounded px-3 py-2 text-sm',
+                        option.value === value
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-gray-900 hover:bg-gray-100'
                       )}
                     >
                       {option.label}
-                    </li>
+                    </div>
                   ))
                 )}
-              </ul>
+              </div>
             </div>
           )}
         </div>

--- a/src/pages/NewTransactionPage.tsx
+++ b/src/pages/NewTransactionPage.tsx
@@ -24,6 +24,24 @@ const transactionSchema = z.object({
 
 type TransactionForm = z.infer<typeof transactionSchema>
 
+// Explicit Tab order for the form fields
+// This maps to: 1=Receita, 2=Despesa, 3=Conta, 4=Categoria, 5=Descricao,
+// 6=Cartao, 7=DataCompra, 8=Valor, 9=Data, 10=Observacoes, 11=Cancelar, 12=Criar
+const TAB_ORDER = {
+  RECEITA: 1,
+  DESPESA: 2,
+  CONTA: 3,
+  CATEGORIA: 4,
+  DESCRICAO: 5,
+  CARTAO: 6,
+  DATA_COMPRA: 7,
+  VALOR: 8,
+  DATA: 9,
+  OBSERVACOES: 10,
+  CANCELAR: 11,
+  CRIAR: 12,
+}
+
 export default function NewTransactionPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -79,7 +97,6 @@ export default function NewTransactionPage() {
 
   const selectedType = watch('type')
   const selectedCreditCardId = watch('creditCardId')
-
   const filteredCategories = categories.filter(cat => cat.type === selectedType)
 
   const onSubmit = (data: TransactionForm) => {
@@ -107,52 +124,51 @@ export default function NewTransactionPage() {
           <CardTitle>Informações da Transação</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <Button
+          {/* The form uses explicit tabIndex to guarantee Tab order, independent of visual layout */}
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="space-y-4"
+            aria-label="Formulário de nova transação"
+          >
+            {/* 1. Tipo: Receita / Despesa */}
+            <div className="grid grid-cols-2 gap-4" role="group" aria-label="Tipo de transação">
+              <button
                 type="button"
-                variant={selectedType === 'INCOME' ? 'default' : 'outline'}
+                tabIndex={TAB_ORDER.RECEITA}
                 onClick={() => setValue('type', 'INCOME')}
+                className={`
+                  h-10 rounded-md border text-sm font-medium transition-colors
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
+                  ${selectedType === 'INCOME'
+                    ? 'border-primary bg-primary text-white'
+                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'}
+                `}
               >
                 Receita
-              </Button>
-              <Button
+              </button>
+              <button
                 type="button"
-                variant={selectedType === 'EXPENSE' ? 'default' : 'outline'}
+                tabIndex={TAB_ORDER.DESPESA}
                 onClick={() => setValue('type', 'EXPENSE')}
+                className={`
+                  h-10 rounded-md border text-sm font-medium transition-colors
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
+                  ${selectedType === 'EXPENSE'
+                    ? 'border-primary bg-primary text-white'
+                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'}
+                `}
               >
                 Despesa
-              </Button>
+              </button>
             </div>
 
-            <Input
-              label="Valor"
-              type="number"
-              step="0.01"
-              placeholder="0,00"
-              {...register('amount', { valueAsNumber: true })}
-              error={errors.amount?.message}
-            />
-
-            <Input
-              label="Data"
-              type="date"
-              {...register('date')}
-              error={errors.date?.message}
-            />
-
-            <Input
-              label="Descrição"
-              placeholder="Ex: Almoço no restaurante"
-              {...register('description')}
-              error={errors.description?.message}
-            />
-
+            {/* 2. Conta */}
             <SearchableSelect
               label="Conta"
+              tabIndex={TAB_ORDER.CONTA}
               options={accounts.map(account => ({
                 value: account.id,
-                label: account.name
+                label: account.name,
               }))}
               value={watch('accountId')}
               onChange={(value) => setValue('accountId', value)}
@@ -160,11 +176,13 @@ export default function NewTransactionPage() {
               error={errors.accountId?.message}
             />
 
+            {/* 3. Categoria */}
             <SearchableSelect
               label="Categoria"
+              tabIndex={TAB_ORDER.CATEGORIA}
               options={filteredCategories.map(category => ({
                 value: category.id,
-                label: category.name
+                label: category.name,
               }))}
               value={watch('categoryId')}
               onChange={(value) => setValue('categoryId', value)}
@@ -172,14 +190,25 @@ export default function NewTransactionPage() {
               error={errors.categoryId?.message}
             />
 
+            {/* 4. Descrição */}
+            <Input
+              label="Descrição"
+              placeholder="Ex: Almoço no restaurante"
+              tabIndex={TAB_ORDER.DESCRICAO}
+              {...register('description')}
+              error={errors.description?.message}
+            />
+
+            {/* 5. Cartão de Crédito */}
             <SearchableSelect
               label="Cartão de Crédito (opcional)"
+              tabIndex={TAB_ORDER.CARTAO}
               options={[
                 { value: '', label: 'Não usar cartão' },
                 ...creditCards.map(card => ({
                   value: card.id,
-                  label: card.name
-                }))
+                  label: card.name,
+                })),
               ]}
               value={watch('creditCardId') || ''}
               onChange={(value) => setValue('creditCardId', value)}
@@ -187,18 +216,42 @@ export default function NewTransactionPage() {
               error={errors.creditCardId?.message}
             />
 
+            {/* 6. Data da compra (only when card is selected) */}
             {selectedCreditCardId && (
               <Input
                 label="Data da compra (opcional)"
                 type="date"
+                tabIndex={TAB_ORDER.DATA_COMPRA}
                 {...register('purchaseDate')}
                 error={errors.purchaseDate?.message}
               />
             )}
 
+            {/* 7. Valor */}
+            <Input
+              label="Valor"
+              type="number"
+              step="0.01"
+              placeholder="0,00"
+              tabIndex={TAB_ORDER.VALOR}
+              {...register('amount', { valueAsNumber: true })}
+              error={errors.amount?.message}
+            />
+
+            {/* 8. Data */}
+            <Input
+              label="Data"
+              type="date"
+              tabIndex={TAB_ORDER.DATA}
+              {...register('date')}
+              error={errors.date?.message}
+            />
+
+            {/* 9. Observações (always last before buttons) */}
             <Textarea
               label="Observações (opcional)"
               placeholder="Observações adicionais..."
+              tabIndex={TAB_ORDER.OBSERVACOES}
               {...register('notes')}
               error={errors.notes?.message}
             />
@@ -211,10 +264,12 @@ export default function NewTransactionPage() {
               </div>
             )}
 
+            {/* 10-11. Botões: Cancelar / Criar */}
             <div className="flex flex-col sm:flex-row gap-3 pt-4">
               <Button
                 type="button"
                 variant="outline"
+                tabIndex={TAB_ORDER.CANCELAR}
                 onClick={() => navigate('/transactions')}
                 className="flex-1"
               >
@@ -222,6 +277,7 @@ export default function NewTransactionPage() {
               </Button>
               <Button
                 type="submit"
+                tabIndex={TAB_ORDER.CRIAR}
                 disabled={createMutation.isPending}
                 className="flex-1"
               >


### PR DESCRIPTION
- Add explicit tabIndex={1-12} on every focusable element in the form (Receita, Despesa, Conta, Categoria, Descricao, Cartao, Data compra, Valor, Data, Observacoes, Cancelar, Criar)
- SearchableSelect trigger is a real <button> that receives tabIndex
- Dropdown items use tabIndex=0 so arrow-key navigation works
- Input/Textarea pass through their own tabIndex via spread props
- Fix: trigger returns focus after selection so Tab continues correctly

Issue: Descricao → Tab was jumping to Observacoes instead of Conta.
Solution: explicit tabIndex on all fields guarantees correct order.